### PR TITLE
Two fixes in GetFromRouteUrl.cs

### DIFF
--- a/src/Sitecore.SharedSource.Wildcard/Pipelines/Mvc/GetPageItem/GetFromRouteUrl.cs
+++ b/src/Sitecore.SharedSource.Wildcard/Pipelines/Mvc/GetPageItem/GetFromRouteUrl.cs
@@ -39,7 +39,10 @@
             char[] chrArray = new char[] { '/' };
             string[] strArrays = url.Split(chrArray, StringSplitOptions.RemoveEmptyEntries);
             url = this.GetPathFromParts(strArrays, routeData);
-            url = url.Remove(0, Sitecore.Context.Site.SiteInfo.VirtualFolder.Length - 1);
+
+            if (url.Length > 0)
+                url = url.Remove(0, Sitecore.Context.Site.SiteInfo.VirtualFolder.Length - 1);
+
             return url;
         }
 
@@ -89,7 +92,10 @@
                 return wildcardItem;
             }
 
-            HttpContext.Current.Items.Add(AppConstants.ContextItemKey, wildcardItem);
+
+            if(!HttpContext.Current.Items.Contains(AppConstants.ContextItemKey))
+                HttpContext.Current.Items.Add(AppConstants.ContextItemKey, wildcardItem);
+
             string itemRelativePath = StringUtil.EnsurePrefix('/', WildcardProvider.GetWildCardItemRelativeSitecorePathFromUrl(path, wildcardItem));
             string itemPath = string.Concat(datasourceReference.TargetItem.Paths.FullPath, itemRelativePath);
             return Context.Database.GetItem(itemPath);

--- a/src/Sitecore.SharedSource.Wildcard/Sitecore.SharedSource.Wildcard.csproj
+++ b/src/Sitecore.SharedSource.Wildcard/Sitecore.SharedSource.Wildcard.csproj
@@ -47,13 +47,13 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Sitecore.ContentSearch">
-      <HintPath>E:\Websites\sandbox.local\Website\bin\Sitecore.ContentSearch.dll</HintPath>
+      <HintPath>References\Sitecore.ContentSearch.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Kernel">
-      <HintPath>E:\Websites\sandbox.local\Website\bin\Sitecore.Kernel.dll</HintPath>
+      <HintPath>References\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc">
-      <HintPath>E:\Websites\sandbox.local\Website\bin\Sitecore.Mvc.dll</HintPath>
+      <HintPath>References\Sitecore.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />


### PR DESCRIPTION
- Changed sitecore dll references to relative path (/References)
- Added check in GetFromRouteUrl.cs/GetPath() to prevent crash in sitecore experience editor
- Added check in GetFromRouteUrl.cs/ResolveItem() to prevent a crash in which an item with the same key would be added to HttpContext.Current.Items